### PR TITLE
Update stolperstein.js

### DIFF
--- a/page/js/stolperstein.js
+++ b/page/js/stolperstein.js
@@ -413,7 +413,7 @@ function makeGeoJsonLayerFromOsmJson(osmJsonData, tokens, status) {
             );
           } else if (/(File|Datei):/.test(refUrl)) {
             description.push(
-              '<a href="' + refUrl + '" target="_blank">' +
+              '<a href="' + refUrl.replace(/ /gi,"_") + '" target="_blank">' +
               '<img src="./images/Clear.gif" /></a>');
           }
         } else {


### PR DESCRIPTION
change Space with underscore in imagetag to show Pictures with space in Filename.
CommonsWikimedia ersetzt Leerzeichen im Dateinamen durch Unterstriche.
wenn die Dateinamen in OSM Tag dann Leerzeichen haben wird dadurch das Bild angezeigt.
Beispiel Node 3696098147 bei dem dann das Bild gezeigt wird.